### PR TITLE
fix(rpc): 修复zrpc中间件导致middleware_gen.go生成失败的问题

### DIFF
--- a/cmd/jzero/.template/rpc/middleware_gen.go.tpl
+++ b/cmd/jzero/.template/rpc/middleware_gen.go.tpl
@@ -18,11 +18,16 @@ var (
     _ = grpc.SupportPackageIsVersion7
 )
 
+// RegisterGen register zrpc middleware
 func RegisterGen(zrpc *zrpc.RpcServer, gw *gateway.Server) {
-	 {{range $v := .HttpMiddlewares}}gw.Use({{$v.Name | FirstUpper}}Middleware)
-     {{end}}
-     {{range $v := .ZrpcMiddlewares}}zrpc.AddUnaryInterceptors({{$v.Name | FirstUpper}}Middleware)
-        zrpc.AddStreamInterceptors({{$v.Name | FirstUpper}}StreamMiddleware){{end}}
+	{{- range $v := .HttpMiddlewares}}
+	gw.Use({{$v.Name | FirstUpper}}Middleware)
+	{{- end}}
+
+	{{- range $v := .ZrpcMiddlewares}}
+	zrpc.AddUnaryInterceptors({{$v.Name | FirstUpper}}Middleware)
+	zrpc.AddStreamInterceptors({{$v.Name | FirstUpper}}StreamMiddleware)
+	{{- end}}
 }
 
 // Define and compile routes


### PR DESCRIPTION
## 问题描述
在RPC模式下，当在proto文件中指定中间件类型为zrpc时，会直接导致`middleware_gen.go`文件无法生成，影响代码生成流程。

## 修复方案
### 问题根因
生成的`middleware_gen.go`文件中，`RegisterGen`方法内不同类型中间件的代码逻辑被混在同一行，导致`cmd/jzero/internal/command/gen/genrpc/middleware.go`第182行的`gosimports.Process`调用执行失败。

### 具体修改
调整模板文件 `cmd/jzero/.template/rpc/middle/middleware_gen.go.tpl` 中`RegisterGen`方法的模板内容，通过格式化代码行结构解决代码混行问题：

修改后的模板内容：
```go
func RegisterGen(zrpc *zrpc.RpcServer, gw *gateway.Server) {
	{{- range $v := .HttpMiddlewares}}
	gw.Use({{$v.Name | FirstUpper}}Middleware)
	{{- end}}

	{{- range $v := .ZrpcMiddlewares}}
	zrpc.AddUnaryInterceptors({{$v.Name | FirstUpper}}Middleware)
	zrpc.AddStreamInterceptors({{$v.Name | FirstUpper}}StreamMiddleware)
	{{- end}}
}