### PR TITLE
feat(genapi): support preserving custom handlers

### DIFF
--- a/cmd/jzero/internal/command/gen/genapi/genapi.go
+++ b/cmd/jzero/internal/command/gen/genapi/genapi.go
@@ -227,6 +227,10 @@ func (ja *JzeroApi) cleanHandlersDir(genCodeApiFiles []string, genCodeApiSpecMap
 		}
 
 		for _, group := range apiSpec.Service.Groups {
+			if !shouldRewriteHandler(group) {
+				continue
+			}
+
 			groupAnnotation := group.GetAnnotation("group")
 			if groupAnnotation == "" {
 				continue
@@ -248,6 +252,11 @@ func (ja *JzeroApi) cleanHandlersDir(genCodeApiFiles []string, genCodeApiSpecMap
 		}
 	}
 	return eg.Wait()
+}
+
+func shouldRewriteHandler(group spec.Group) bool {
+	rewriteHandler := strings.TrimSpace(group.GetAnnotation("rewrite_handler"))
+	return rewriteHandler == "" || cast.ToBool(rewriteHandler)
 }
 
 // prepareTemplateDir 准备模板目录，返回临时目录路径

--- a/cmd/jzero/internal/command/gen/genapi/handler.go
+++ b/cmd/jzero/internal/command/gen/genapi/handler.go
@@ -28,12 +28,13 @@ import (
 )
 
 type HandlerFile struct {
-	Package     string
-	Group       string
-	Compact     bool
-	Handler     string
-	Path        string
-	ApiFilepath string
+	Package        string
+	Group          string
+	Compact        bool
+	Handler        string
+	RewriteHandler bool
+	Path           string
+	ApiFilepath    string
 }
 
 func (ja *JzeroApi) getAllHandlerFiles(apiFilepath string, apiSpec *spec.ApiSpec) ([]HandlerFile, error) {
@@ -48,11 +49,12 @@ func (ja *JzeroApi) getAllHandlerFiles(apiFilepath string, apiSpec *spec.ApiSpec
 			fp := filepath.Join(config.C.Wd(), "internal", "handler", group.GetAnnotation("group"), namingFormat+".go")
 
 			hf := HandlerFile{
-				ApiFilepath: apiFilepath,
-				Path:        fp,
-				Group:       group.GetAnnotation("group"),
-				Compact:     cast.ToBool(group.GetAnnotation("compact_handler")),
-				Handler:     route.Handler,
+				ApiFilepath:    apiFilepath,
+				Path:           fp,
+				Group:          group.GetAnnotation("group"),
+				Compact:        cast.ToBool(group.GetAnnotation("compact_handler")),
+				Handler:        route.Handler,
+				RewriteHandler: shouldRewriteHandler(group),
 			}
 			if goPackage, ok := apiSpec.Info.Properties["go_package"]; ok {
 				hf.Package = goPackage
@@ -73,6 +75,9 @@ func (ja *JzeroApi) patchHandler(file HandlerFile, genCodeApiSpecMap map[string]
 
 	if pathx.FileExists(newFilePath) {
 		_ = os.Remove(file.Path)
+		if !file.RewriteHandler {
+			return nil
+		}
 		file.Path = newFilePath
 	}
 

--- a/cmd/jzero/internal/command/gen/genapi/handler_test.go
+++ b/cmd/jzero/internal/command/gen/genapi/handler_test.go
@@ -1,6 +1,8 @@
 package genapi
 
 import (
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -102,7 +104,7 @@ func TestPatchHandlerKeepsExistingHandlerWhenRewriteHandlerFalse(t *testing.T) {
 	if string(data) != string(existingContent) {
 		t.Fatalf("patchHandler() should keep existing handler unchanged, got:\n%s", data)
 	}
-	if _, err = os.Stat(generatedPath); !os.IsNotExist(err) {
+	if _, err = os.Stat(generatedPath); !errors.Is(err, fs.ErrNotExist) {
 		t.Fatalf("patchHandler() should remove generated handler when final handler exists, stat err = %v", err)
 	}
 }

--- a/cmd/jzero/internal/command/gen/genapi/handler_test.go
+++ b/cmd/jzero/internal/command/gen/genapi/handler_test.go
@@ -1,0 +1,108 @@
+package genapi
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/zeromicro/go-zero/tools/goctl/api/spec"
+)
+
+func withTempWorkDir(t *testing.T) string {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() error = %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(oldWd)
+	})
+
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("Chdir() error = %v", err)
+	}
+
+	return tmpDir
+}
+
+func TestCleanHandlersDirKeepsHandlersWhenRewriteHandlerFalse(t *testing.T) {
+	withTempWorkDir(t)
+
+	handlerPath := filepath.Join("internal", "handler", "user", "custom.go")
+	if err := os.MkdirAll(filepath.Dir(handlerPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(handlerPath, []byte("package user\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	apiFile := filepath.Join("desc", "api", "user.api")
+	apiSpecMap := map[string]*spec.ApiSpec{
+		apiFile: {
+			Service: spec.Service{
+				Groups: []spec.Group{
+					{
+						Annotation: spec.Annotation{
+							Properties: map[string]string{
+								"group":           "user",
+								"rewrite_handler": "false",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ja := &JzeroApi{}
+	if err := ja.cleanHandlersDir([]string{apiFile}, apiSpecMap); err != nil {
+		t.Fatalf("cleanHandlersDir() error = %v", err)
+	}
+
+	if _, err := os.Stat(handlerPath); err != nil {
+		t.Fatalf("cleanHandlersDir() should keep handler when rewrite_handler is false, stat err = %v", err)
+	}
+}
+
+func TestPatchHandlerKeepsExistingHandlerWhenRewriteHandlerFalse(t *testing.T) {
+	tmpDir := withTempWorkDir(t)
+
+	handlerDir := filepath.Join(tmpDir, "internal", "handler", "user")
+	if err := os.MkdirAll(handlerDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	existingPath := filepath.Join(handlerDir, "foo.go")
+	existingContent := []byte("package user\n\nfunc Foo(  ){}\n")
+	if err := os.WriteFile(existingPath, existingContent, 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	generatedPath := filepath.Join(handlerDir, "foo_handler.go")
+	if err := os.WriteFile(generatedPath, []byte("package user\n\nfunc FooHandler() {}\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	ja := &JzeroApi{}
+	err := ja.patchHandler(HandlerFile{
+		Path:           generatedPath,
+		Handler:        "Foo",
+		RewriteHandler: false,
+	}, nil)
+	if err != nil {
+		t.Fatalf("patchHandler() error = %v", err)
+	}
+
+	data, err := os.ReadFile(existingPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if string(data) != string(existingContent) {
+		t.Fatalf("patchHandler() should keep existing handler unchanged, got:\n%s", data)
+	}
+	if _, err = os.Stat(generatedPath); !os.IsNotExist(err) {
+		t.Fatalf("patchHandler() should remove generated handler when final handler exists, stat err = %v", err)
+	}
+}

--- a/cmd/jzero/internal/command/gen/genapi/logic.go
+++ b/cmd/jzero/internal/command/gen/genapi/logic.go
@@ -23,15 +23,16 @@ import (
 )
 
 type LogicFile struct {
-	Package      string
-	Group        string
-	Handler      string
-	New          bool // 是否是新生成的 logic 文件
-	Compact      bool // 是否合并 logic 文件
-	Path         string
-	DescFilepath string
-	RequestType  spec.Type
-	ResponseType spec.Type
+	Package        string
+	Group          string
+	Handler        string
+	New            bool // 是否是新生成的 logic 文件
+	Compact        bool // 是否合并 logic 文件
+	RewriteHandler bool
+	Path           string
+	DescFilepath   string
+	RequestType    spec.Type
+	ResponseType   spec.Type
 }
 
 func (ja *JzeroApi) getAllLogicFiles(apiFilepath string, apiSpec *spec.ApiSpec) ([]LogicFile, error) {
@@ -46,14 +47,15 @@ func (ja *JzeroApi) getAllLogicFiles(apiFilepath string, apiSpec *spec.ApiSpec) 
 			fp := filepath.Join(config.C.Wd(), "internal", "logic", group.GetAnnotation("group"), namingFormat+".go")
 
 			hf := LogicFile{
-				DescFilepath: apiFilepath,
-				Path:         fp,
-				Group:        group.GetAnnotation("group"),
-				New:          !pathx.FileExists(fp),
-				Compact:      cast.ToBool(group.GetAnnotation("compact_logic")),
-				Handler:      route.Handler,
-				RequestType:  route.RequestType,
-				ResponseType: route.ResponseType,
+				DescFilepath:   apiFilepath,
+				Path:           fp,
+				Group:          group.GetAnnotation("group"),
+				New:            !pathx.FileExists(fp),
+				Compact:        cast.ToBool(group.GetAnnotation("compact_logic")),
+				RewriteHandler: shouldRewriteHandler(group),
+				Handler:        route.Handler,
+				RequestType:    route.RequestType,
+				ResponseType:   route.ResponseType,
 			}
 			if goPackage, ok := apiSpec.Info.Properties["go_package"]; ok {
 				hf.Package = goPackage
@@ -75,6 +77,9 @@ func (ja *JzeroApi) patchLogic(file LogicFile, genCodeApiSpecMap map[string]*spe
 
 	if pathx.FileExists(newFilePath) {
 		_ = os.Remove(file.Path)
+		if !file.RewriteHandler {
+			return nil
+		}
 		file.Path = newFilePath
 	}
 

--- a/cmd/jzero/internal/command/gen/genapi/logic_test.go
+++ b/cmd/jzero/internal/command/gen/genapi/logic_test.go
@@ -1,6 +1,8 @@
 package genapi
 
 import (
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -79,7 +81,7 @@ func (l *Login) Login(req *types.LoginRequest) (resp *types.LoginResponse, err e
 	if string(data) != string(existingContent) {
 		t.Fatalf("patchLogic() should keep existing logic unchanged, got:\n%s", data)
 	}
-	if _, err = os.Stat(generatedPath); !os.IsNotExist(err) {
+	if _, err = os.Stat(generatedPath); !errors.Is(err, fs.ErrNotExist) {
 		t.Fatalf("patchLogic() should remove generated logic when final logic exists, stat err = %v", err)
 	}
 }

--- a/cmd/jzero/internal/command/gen/genapi/logic_test.go
+++ b/cmd/jzero/internal/command/gen/genapi/logic_test.go
@@ -1,0 +1,85 @@
+package genapi
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/zeromicro/go-zero/tools/goctl/api/spec"
+)
+
+func TestPatchLogicKeepsExistingLogicWhenRewriteHandlerFalse(t *testing.T) {
+	tmpDir := withTempWorkDir(t)
+
+	logicDir := filepath.Join(tmpDir, "internal", "logic", "user")
+	if err := os.MkdirAll(logicDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	existingPath := filepath.Join(logicDir, "login.go")
+	existingContent := []byte(`package user
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/zeromicro/go-zero/core/logx"
+	"example.com/app/internal/svc"
+)
+
+type Login struct {
+	logx.Logger
+	ctx    context.Context
+	svcCtx *svc.ServiceContext
+	r      *http.Request
+	w      http.ResponseWriter
+}
+
+func NewLogin(ctx context.Context, svcCtx *svc.ServiceContext, r *http.Request, w http.ResponseWriter) *Login {
+	return &Login{
+		Logger: logx.WithContext(ctx),
+		ctx:    ctx,
+		svcCtx: svcCtx,
+		r:      r,
+		w:      w,
+	}
+}
+
+func (l *Login) Login(req *types.LoginRequest) (resp *types.LoginResponse, err error) {
+	return nil, nil
+}
+`)
+	if err := os.WriteFile(existingPath, existingContent, 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	generatedPath := filepath.Join(logicDir, "login_logic.go")
+	if err := os.WriteFile(generatedPath, []byte("package user\n\ntype LoginLogic struct{}\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	apiFile := filepath.Join("desc", "api", "user.api")
+	ja := &JzeroApi{}
+	err := ja.patchLogic(LogicFile{
+		Path:           generatedPath,
+		DescFilepath:   apiFile,
+		Handler:        "Login",
+		RewriteHandler: false,
+		RequestType:    spec.DefineStruct{RawName: "LoginRequest"},
+		ResponseType:   spec.DefineStruct{RawName: "LoginResponse"},
+	}, map[string]*spec.ApiSpec{apiFile: {}})
+	if err != nil {
+		t.Fatalf("patchLogic() error = %v", err)
+	}
+
+	data, err := os.ReadFile(existingPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if string(data) != string(existingContent) {
+		t.Fatalf("patchLogic() should keep existing logic unchanged, got:\n%s", data)
+	}
+	if _, err = os.Stat(generatedPath); !os.IsNotExist(err) {
+		t.Fatalf("patchLogic() should remove generated logic when final logic exists, stat err = %v", err)
+	}
+}

--- a/docs/src/guide/api.md
+++ b/docs/src/guide/api.md
@@ -12,6 +12,7 @@ api is go-zero's self-developed domain-specific language (hereinafter referred t
 jzero has extended api syntax, supporting the following features:
 * `go_package`: Generates go types in defined packages, allowing different api files to have same-named type definitions, consistent with proto's `go_package`
 * `compact_handler`: Generates handlers of the same route group in one file, reducing file count, consistent with proto's server module
+* `rewrite_handler`: Controls whether existing handler files and their matching logic files are rewritten during code generation. The default is `true`; set it to `false` to keep custom handler and logic code.
 
 ## api definition
 
@@ -123,5 +124,21 @@ service simpleapi {
 
 	@handler DeleteUserHandler
 	get /system/user/deleteUser (DeleteUserRequest) returns (DeleteUserResponse)
+}
+```
+
+## Keep custom handler code
+
+When a handler needs custom `http.ResponseWriter` or `*http.Request` handling, set `rewrite_handler: false` on the route group. Existing handler files and their matching logic files will be kept when running `jzero gen`, while missing files can still be generated.
+
+```shell {4}
+@server (
+	prefix:          /api/v1
+	group:           system/webhook
+	rewrite_handler: false
+)
+service simpleapi {
+	@handler ReceiveWebhook
+	post /system/webhook/receive (WebhookRequest) returns (WebhookResponse)
 }
 ```

--- a/docs/src/zh-CN/guide/api.md
+++ b/docs/src/zh-CN/guide/api.md
@@ -13,6 +13,7 @@ jzero 扩展了 api 语法, 支持了一下特性:
 
 * `go_package`: 将 go types 生成在定义的 package 中, 所以能支持不同 api 文件的 type 定义可以同名, 保持和 proto 中的 `go_package` 一致
 * `compact_handler`: 能将同一组路由的 handler 生成在同一个文件中, 减少文件的数量, 保持和 proto 的 server 模块一致
+* `rewrite_handler`: 控制生成代码时是否重写已存在的 handler 文件及其对应 logic 文件, 默认为 `true`; 设置为 `false` 可保留自定义 handler 和 logic 代码
 
 ## api 定义
 
@@ -124,5 +125,21 @@ service simpleapi {
 
 	@handler DeleteUserHandler
 	get /system/user/deleteUser (DeleteUserRequest) returns (DeleteUserResponse)
+}
+```
+
+## 保留自定义 handler 代码
+
+当 handler 需要自定义处理 `http.ResponseWriter` 或 `*http.Request` 时, 可以在路由组上设置 `rewrite_handler: false`. 再次执行 `jzero gen` 时, 已存在的 handler 文件及其对应 logic 文件会被保留, 缺失的文件仍可继续生成.
+
+```shell {4}
+@server (
+	prefix:          /api/v1
+	group:           system/webhook
+	rewrite_handler: false
+)
+service simpleapi {
+	@handler ReceiveWebhook
+	post /system/webhook/receive (WebhookRequest) returns (WebhookResponse)
 }
 ```


### PR DESCRIPTION
## Summary
- add `rewrite_handler` support for api route groups, defaulting to existing rewrite behavior
- preserve existing handler files and their matching logic files when `rewrite_handler: false` is set
- keep missing handler/logic files generatable for new routes
- document the option in English and Chinese API guides

Fixes #459

## Tests
- `jzero format -d --git-change=false` from an LF checkout
- `jzero format -d --git-change=true` from the working checkout
- `go test ./...` from `cmd/jzero`
- `go test ./...` from repository root
- `git diff --check`